### PR TITLE
feat(infra): add pr-title checking action

### DIFF
--- a/.github/workflows/pr-title
+++ b/.github/workflows/pr-title
@@ -1,0 +1,20 @@
+name: "Lint PR Title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a github action that lints the PR titles, ensuring they conform to conventional commit messages (see conventional commits -> https://www.conventionalcommits.org/en/v1.0.0/)